### PR TITLE
Fix issues around moving from rhvm-dependencies package

### DIFF
--- a/ovirt-dependencies.spec.in
+++ b/ovirt-dependencies.spec.in
@@ -33,6 +33,10 @@ Provides:   bundled(spring-jdbc) = @SPRING_VERSION@
 Provides:   bundled(spring-test) = @SPRING_VERSION@
 Provides:   bundled(spring-tx) = @SPRING_VERSION@
 
+# Required due to upgrade issues around moving from rhvm-dependencies to ovirt-dependencies
+Provides:  rhvm-dependencies
+Obsoletes:  rhvm-dependencies < 4.5.0
+
 %description
 oVirt 3rd party dependencies
 


### PR DESCRIPTION
1. Obsoletes rhvm-dependencies package < 4.5.0 to switch from
   rhvm-dependencies to ovirt-dependencies
2. Provides rhvm-dependencies to bypass the problem that
   rhvm-dependencies is required by rhvm-setup-plugins

Signed-off-by: Martin Perina <mperina@redhat.com>
