### PR TITLE
pom: update scm reference

### DIFF
--- a/pom.xml.in
+++ b/pom.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (c) 2014-2021 Red Hat, Inc.
+Copyright (c) 2014-2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ limitations under the License.
     </developers>
 
     <scm>
-        <connection>scm:git:git://gerrit.ovirt.org/ovirt-dependencies.git</connection>
-        <developerConnection>scm:git:git://gerrit.ovirt.org/ovirt-dependencies.git</developerConnection>
-        <url>git://gerrit.ovirt.org/ovirt-dependencies.git</url>
+        <connection>scm:git:https://github.com/oVirt/ovirt-dependencies.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:oVirt/ovirt-dependencies.git</developerConnection>
+        <url>https://github.com/oVirt/ovirt-dependencies</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
update scm references pointing to GitHub instead of Gerrit