### PR TITLE
Mark repo dir as safe for COPR builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -2,9 +2,16 @@
 # spec: passed by copr telling which spec file should be used;
 #       using for selecting the right src.rpm to be copied.
 
+.PHONY: installdeps git_cfg_safe srpm
+
 installdeps:
 	dnf -y install coreutils curl dnf-utils findutils git java-11-openjdk-devel make maven rpmdevtools sed
 
-srpm: installdeps
+git_cfg_safe:
+	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+	# git commands won't work because of the fix for CVE-2022-24765
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: installdeps git_cfg_safe
 	.automation/build-srpm.sh
 	find . -name '*.src.rpm' -exec cp {} $(outdir) \;


### PR DESCRIPTION
git 2.35.2 contains a fix for CVE-2022-24765, which fails running any
git command in a repository directory, which is not owned by the current
user. This state is standard for COPR builds, which are running inside
mock, so we need to mark that directory as safe.

Signed-off-by: Martin Perina <mperina@redhat.com>
